### PR TITLE
Package: Fix tls_certs.py location

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         ["walter_modem/mixins/__init__.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/__init__.py"],
         ["walter_modem/mixins/common.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/common.py"],
         ["walter_modem/mixins/sim_network.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/sim_network.py"],
-        ["walter_modem/mixins/tls_certs.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/sim_network.py"],
+        ["walter_modem/mixins/tls_certs.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/tls_certs.py"],
         ["walter_modem/mixins/gnss.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/gnss.py"],
         ["walter_modem/mixins/http.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/http.py"],
         ["walter_modem/mixins/mqtt.py", "github:QuickSpot/walter-micropython/walter_modem/mixins/mqtt.py"],


### PR DESCRIPTION
Fix file used to install `tls_certs.py`, This resolves #17. Seems there may previously have been a typo using the `sim_network.py` file instead of the intended file.