### PR TITLE
Coap

### DIFF
--- a/tests/modem_library/test_coap.py
+++ b/tests/modem_library/test_coap.py
@@ -1,0 +1,972 @@
+import asyncio
+
+from minimal_unittest import (
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+)
+
+from walter_modem import Modem
+from walter_modem.enums import (
+    WalterModemState,
+    WalterModemOpState,
+    WalterModemCoapCloseCause,
+    WalterModemCoapMethod,
+    WalterModemCoapType,
+    WalterModemCoapResponseCode,
+    WalterModemCoapOptionAction,
+    WalterModemCoapOption,
+    WalterModemCoapContentType
+)
+from walter_modem.structs import (
+    ModemRsp,
+    ModemCoapContextState,
+    ModemCoapResponse,
+    ModemCoapOption
+)
+
+# To avoid disconnecting & reconnecting from the network too frequently;
+# A single modem library instance is re-used, keeping a network connection open
+# from the moment RequireNetworkConnection was first inheriteed.
+modem = Modem()
+
+class TestCoapContextCreate(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):  
+    async def async_setup(self):
+        await modem.begin()
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=1',
+            at_rsp=b'OK'
+        )
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=2',
+            at_rsp=b'OK'
+        )
+
+        modem.coap_context_states[0].rings.clear()
+        modem.coap_context_states[1].rings.clear()
+        modem.coap_context_states[2].rings.clear()
+
+    # Context ID range validation
+
+    async def test_fails_below_min_ctx_id(self):
+        self.assert_false(await modem.coap_context_create(ctx_id=-1))
+
+    async def test_fails_above_max_ctx_id(self):
+        self.assert_false(await modem.coap_context_create(ctx_id=3))
+
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_context_create(ctx_id=7, rsp=modem_rsp)
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, modem_rsp.result)
+
+    # Timeout range validation
+
+    async def test_fails_below_min_timeout(self):
+        self.assert_false(await modem.coap_context_create(ctx_id=0, timeout=0))
+
+    async def test_fails_above_max_timeout(self):
+        self.assert_false(await modem.coap_context_create(ctx_id=0, timeout=121))
+
+    async def test_rsp_result_error_on_invalid_timeout(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_context_create(ctx_id=0, timeout=142, rsp=modem_rsp)
+        self.assert_equal(WalterModemState.ERROR, modem_rsp.result)
+
+    # AT command format
+
+    async def test_sends_expected_at_cmd(self):
+        await self.assert_sends_at_command(
+            modem,
+            'AT+SQNCOAPCREATE=0,"test",5683,5683,0,60',
+            lambda: modem.coap_context_create(
+                ctx_id=0,
+                server_address='test',
+                server_port=5683,
+                local_port=5683,
+                timeout=60,
+                dtls=False
+            )
+        )
+
+    # Method run
+
+    async def test_fails_on_unreachable_server(self):
+        self.assert_false(await modem.coap_context_create(
+            ctx_id=0,
+            server_address='totally_valid_address',
+            server_port=5555
+        ))
+
+    async def test_succeeds_on_reachable_server(self):
+        self.assert_true(await modem.coap_context_create(
+            ctx_id=0,
+            server_address='coap.me',
+            server_port=5683
+        ))
+
+    async def test_succeeds_on_listen_mode(self):
+        self.assert_true(await modem.coap_context_create(
+            ctx_id=1,
+            local_port=5683
+        ))
+
+    # Mirror state
+
+    async def test_ctx_0_mirror_state_set(self):
+        self.assert_is_instance(modem.coap_context_states[0], ModemCoapContextState)
+    
+    async def test_ctx_1_mirror_state_set(self):
+        self.assert_is_instance(modem.coap_context_states[1], ModemCoapContextState)
+    
+    async def test_ctx_2_mirror_state_set(self):
+        self.assert_is_instance(modem.coap_context_states[2], ModemCoapContextState)
+    
+    async def test_ctx_state_not_configured_after_failed_run(self):
+        await modem.coap_context_create(
+            ctx_id=2,
+            server_address='totally_valid_address',
+            server_port=5556
+        )
+        self.assert_false(modem.coap_context_states[2].configured)
+    
+    async def test_ctx_state_configured_after_successful_run(self):
+        await modem.coap_context_create(
+            ctx_id=2,
+            server_address='coap.me',
+            server_port=5683
+        )
+        self.assert_true(modem.coap_context_states[2].configured)
+    
+    async def test_ctx_state_configured_mirrors_connected(self):
+        self.assert_is(
+            modem.coap_context_states[0].configured,
+            modem.coap_context_states[0].connected
+        )
+
+class TestCoapContextClose(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=1,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )
+    
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+
+    # Context ID range validation
+
+    async def test_fails_below_min_ctx_id(self):
+        self.assert_false(await modem.coap_context_close(ctx_id=-1))
+
+    async def test_fails_above_max_ctx_id(self):
+        self.assert_false(await modem.coap_context_close(ctx_id=3))
+
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_context_close(ctx_id=7, rsp=modem_rsp)
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, modem_rsp.result)
+
+    # Method run
+
+    async def test_succeeds_closing_active_connection(self):
+        self.assert_true(await modem.coap_context_close(ctx_id=1))
+    
+    # Mirror state
+
+    async def test_ctx_state_not_configured_after_close(self):
+        self.assert_false(modem.coap_context_states[1].configured)
+    
+    async def test_ctx_state_not_connected_after_close(self):
+        self.assert_false(modem.coap_context_states[1].connected)
+    
+    async def test_ctx_state_cause_equals_user_after_manual_close(self):
+        self.assert_equal(WalterModemCoapCloseCause.USER, modem.coap_context_states[1].cause)
+    
+    async def test_ctx_state_cause_equals_network_after_network_close(self):
+        await modem.set_op_state(WalterModemOpState.MINIMUM)
+        await asyncio.sleep(2) # closed URC should've been triggered by now
+        self.assert_equal(WalterModemCoapCloseCause.NETWORK, modem.coap_context_states[0].cause)
+
+class TestCoapSetOptions(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'OK'
+        )
+    
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+    
+    # Context ID range validation
+    
+    async def test_fails_below_min_ctx_id(self):
+        self.assert_false(await modem.coap_set_options(
+            ctx_id=-1,
+            action=WalterModemCoapOptionAction.READ,
+            option=WalterModemCoapOption.URI_PATH
+        ))
+    
+    async def test_fails_above_max_ctx_id(self):
+        self.assert_false(await modem.coap_set_options(
+            ctx_id=3,
+            action=WalterModemCoapOptionAction.READ,
+            option=WalterModemCoapOption.URI_PATH
+        ))
+    
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_set_options(
+            ctx_id=7,
+            action=WalterModemCoapOptionAction.READ,
+            option=WalterModemCoapOption.URI_PATH,
+            rsp=modem_rsp
+        )
+
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, modem_rsp.result)
+    
+    # Repeatable options validtion
+
+    async def test_multiple_values_fails_on_non_repeatable_option(self):
+        self.assert_false(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.SET,
+            option=WalterModemCoapOption.CONTENT_TYPE,
+            value=(WalterModemCoapContentType.TEXT_PLAIN, WalterModemCoapContentType.IMAGE_JPEG)
+        ))
+    
+    async def test_multiple_values_fails_above_max(self):
+        self.assert_false(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.SET,
+            option=WalterModemCoapOption.URI_PATH,
+            value=('Why', 'did', 'the', 'modem', 'break', 'up?', '...', 'signal', 'loss', ':)')
+        ))
+    
+    # AT command format
+
+    async def test_sends_expected_at_cmd(self):
+        await self.assert_sends_at_command(
+            modem,
+            'AT+SQNCOAPOPT=0,0,11,".well-known","core"',
+            lambda: modem.coap_set_options(
+                ctx_id=0,
+                action=WalterModemCoapOptionAction.SET,
+                option=WalterModemCoapOption.URI_PATH,
+                value=('.well-known','core')
+            )
+        )
+
+        await modem._run_cmd('AT+SQNCOAPOPT=0,1,11', b'OK')
+    
+    # Action: SET
+
+    async def test_action_set_runs(self):
+        self.assert_true(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.SET,
+            option=WalterModemCoapOption.CONTENT_TYPE,
+            value=WalterModemCoapContentType.TEXT_PLAIN
+        ))
+
+        await modem._run_cmd('AT+SQNCOAPOPT=0,1,12', b'OK')
+
+    # Action: DELETE
+
+    async def test_action_delete_runs(self):
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,12,"0"', b'OK')
+
+        self.assert_true(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.DELETE,
+            option=WalterModemCoapOption.CONTENT_TYPE
+        ))
+    
+    # Action: READ
+
+    async def test_action_read_runs(self):
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,12,"50"', b'OK')
+
+        self.assert_true(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.READ,
+            option=WalterModemCoapOption.CONTENT_TYPE
+        ))
+
+        await modem._run_cmd('AT+SQNCOAPOPT=0,1,12', b'OK')
+    
+    async def test_action_read_sets_option_value_in_rsp(self):
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,".well-known","core"', b'OK')
+
+        modem_rsp = ModemRsp()
+        await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.READ,
+            option=WalterModemCoapOption.URI_PATH,
+            rsp=modem_rsp
+        )
+        
+        expected = ModemCoapOption(0, 11, '".well-known","core"')
+        reality = modem_rsp.coap_options
+        self.assert_equal(
+            (expected.ctx_id, expected.option, expected.value),
+            (reality.ctx_id, reality.option, reality.value)
+        )
+
+        await modem._run_cmd('AT+SQNCOAPOPT=0,1,11', b'OK')
+
+    # Action: EXTEND
+
+    async def test_action_extend_runs(self):
+        modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"the","answer","is","always"', b'OK')
+
+        self.assert_true(await modem.coap_set_options(
+            ctx_id=0,
+            action=WalterModemCoapOptionAction.EXTEND,
+            option=WalterModemCoapOption.URI_PATH,
+            value='yes'
+        ))
+
+        modem._run_cmd('AT+SQNCOAPOPT=0,1,11', b'OK')
+    
+class TestCoapSetHeader(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )   
+
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+
+    # Context ID range validation
+    
+    async def test_fails_below_min_ctx_id(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=-1,
+            msg_id=42
+        ))
+    
+    async def test_fails_above_max_ctx_id(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=3,
+            msg_id=1701
+        ))
+    
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_set_header(
+            ctx_id=7,
+            msg_id=19,
+            rsp=modem_rsp
+        )
+
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, modem_rsp.result)
+    
+    # Message ID validation
+
+    async def test_fails_below_min_msg_id(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=0,
+            msg_id=-1
+        ))
+
+    async def test_fails_below_min_msg_id(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=0,
+            msg_id=65536
+        ))
+
+    async def test_rsp_result_error_on_invalid_msg_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_set_header(
+            ctx_id=0,
+            msg_id=75454,
+            rsp=modem_rsp
+        )
+
+        self.assert_equal(WalterModemState.ERROR, modem_rsp.result)
+    
+    # Token validation
+
+    async def test_fails_on_too_long_token(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=0,
+            token='D1AD7314FB251B3FC'
+        ))
+    
+    async def test_fails_on_invalid_hex_in_token(self):
+        self.assert_false(await modem.coap_set_header(
+            ctx_id=0,
+            token='NCC-1701'
+        ))
+    
+    async def test_rsp_result_error_on_invalid_token(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_set_header(
+            ctx_id=0,
+            token='NCC-1701-D',
+            rsp=modem_rsp
+        )
+
+        self.assert_equal(WalterModemState.ERROR, modem_rsp.result)
+    
+    # AT command format
+
+    async def test_sends_expected_at_cmd(self):
+        await self.assert_sends_at_command(
+            modem,
+            'AT+SQNCOAPHDR=0,47457,"74EBFDE0"',
+            lambda: modem.coap_set_header(
+                ctx_id=0,
+                msg_id=47457,
+                token='74EBFDE0'
+            )
+        )
+
+class TestCoapSend(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )
+    
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+        modem.coap_context_states[0].rings.clear()
+    
+    # Context ID range validation
+    
+    async def test_fails_below_min_ctx_id(self):
+        self.assert_false(await modem.coap_send(
+            ctx_id=-1,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=0,
+            data=None
+        ))
+
+    async def test_fails_above_max_ctx_id(self):
+        self.assert_false(await modem.coap_send(
+            ctx_id=3,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=0,
+            data=None
+        ))
+
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_send(
+            ctx_id=7,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=0,
+            data=None,
+            rsp=modem_rsp
+        )
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, modem_rsp.result)
+
+    # Length range validation
+
+    async def test_fails_below_min_length(self):
+        self.assert_false(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=-1,
+            data=None
+        ))
+
+    async def test_fails_above_max_length(self):
+        self.assert_false(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=1025,  # Max is 1024 per documentation
+            data=None
+        ))
+
+    async def test_rsp_result_error_on_invalid_length(self):
+        modem_rsp = ModemRsp()
+        await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=2000,
+            data=None,
+            rsp=modem_rsp
+        )
+        self.assert_equal(WalterModemState.ERROR, modem_rsp.result)
+
+    # AT command format
+
+    async def test_sends_expected_at_cmd_get_no_data(self):
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,".well-known"',b'OK')
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"core"',b'OK')
+        await self.assert_sends_at_command(
+            modem,
+            'AT+SQNCOAPSEND=0,0,1,0',
+            lambda: modem.coap_send(
+                ctx_id=0,
+                m_type=WalterModemCoapType.CON,
+                method=WalterModemCoapMethod.GET,
+                length=0,
+                data=None
+            )
+        )
+
+    # Method run tests with coap.me endpoints
+    # GET tests
+
+    async def test_get_well_known_core(self):
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=0,
+            data=None,
+            path='/.well-known/core'
+        ))
+
+    async def test_get_test_endpoint(self):
+        await asyncio.sleep(5) # Lower chances of another ring-(response) coming in.
+        modem.coap_context_states[0].rings.clear()
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.GET,
+            length=0,
+            data=None,
+            path='test' # Testing different ways of giving path along (with and without /)
+        ))
+
+    async def test_get_test_endpoint_rang_205_content(self):
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        
+        ring = modem.coap_context_states[0].rings.pop()
+        self.assert_equal(
+            WalterModemCoapResponseCode.CONTENT,
+            ring.rsp_code
+        )
+
+    # POST tests
+
+    async def test_post_test_endpoint(self):
+        test_data = 'Hello from Walter Modem'
+        modem.coap_context_states[0].rings.clear()
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.POST,
+            length=len(test_data),
+            data=test_data,
+            path='/test',
+            content_type=WalterModemCoapContentType.APPLICATION_JSON
+        ))
+
+    async def test_post_test_endpoint_rang_201_created(self):
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        
+        ring = modem.coap_context_states[0].rings.pop()
+        self.assert_equal(
+            WalterModemCoapResponseCode.CREATED,
+            ring.rsp_code
+        )
+
+    # PUT tests
+
+    async def test_put_test_endpoint(self):
+        test_data = 'Updated resource data'
+        modem.coap_context_states[0].rings.clear()
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.PUT,
+            length=len(test_data),
+            data=test_data,
+            path='test'
+        ))
+
+    async def test_put_test_endpoint_rang_204_changed(self):
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        
+        ring = modem.coap_context_states[0].rings.pop()
+        self.assert_equal(
+            WalterModemCoapResponseCode.CHANGED,
+            ring.rsp_code
+        )
+
+    # DELETE tests
+
+    async def test_delete_test_endpoint(self):
+        modem.coap_context_states[0].rings.clear()
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.DELETE,
+            length=0,
+            data=None,
+            path='test'
+        ))
+
+    async def test_delete_test_endpoint_rang_202_deleted(self):
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        
+        ring = modem.coap_context_states[0].rings.pop()
+        self.assert_equal(
+            WalterModemCoapResponseCode.DELETED,
+            ring.rsp_code
+        )
+
+    # Data Formats
+
+    async def test_str_data_format(self):
+        test_string = 'String payload test'
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.POST,
+            length=len(test_string),
+            data=test_string,
+            path='test'
+        ))
+
+    async def test_bytes_data_format(self):
+        test_binary = b'\x01\x02\x03\x04\x05'
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.POST,
+            length=len(test_binary),
+            data=test_binary
+        ))
+
+    # Length calculation tests
+
+    async def test_auto_length_calculation_with_string(self):
+        test_data = 'Auto-length test'
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.POST,
+            data=test_data,
+            path='.well-known/core'
+        ))
+        
+    async def test_auto_length_calculation_with_bytes(self):
+        test_data = b'Binary auto-length test'
+        self.assert_true(await modem.coap_send(
+            ctx_id=0,
+            m_type=WalterModemCoapType.CON,
+            method=WalterModemCoapMethod.POST,
+            data=test_data,
+            path='/.well-known/core'
+        ))
+
+class TestCoapReceiveData(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+    
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )
+
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+
+    # Context ID range validation
+
+    async def test_fails_below_min_ctx_id(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_data(
+            ctx_id=-1,
+            msg_id=1,
+            length=10
+        ))
+
+    async def test_fails_above_max_ctx_id(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_data(
+            ctx_id=3,
+            msg_id=1,
+            length=10
+        ))
+
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        rsp = ModemRsp()
+        await modem.coap_receive_data(ctx_id=7, msg_id=1, length=10, rsp=rsp)
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, rsp.result)
+
+    # max_bytes range validation
+
+    async def test_fails_below_min_max_bytes(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_data(
+            ctx_id=0,
+            msg_id=1,
+            length=10,
+            max_bytes=-1,
+        ))
+
+    async def test_fails_above_max_max_bytes(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_data(
+            ctx_id=0,
+            msg_id=1,
+            length=10,
+            max_bytes=2048
+        ))
+
+    async def test_rsp_result_error_on_invalid_max_bytes(self):
+        rsp = ModemRsp()
+        await modem.coap_receive_data(ctx_id=0, msg_id=1, length=10, max_bytes=-1, rsp=rsp)
+        self.assert_equal(WalterModemState.ERROR, rsp.result)
+
+    # Length validation
+
+    async def test_fails_with_negative_length(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_data(
+            ctx_id=0,
+            msg_id=1,
+            length=-1
+        ))
+
+    async def test_rsp_result_error_on_negative_length(self):
+        rsp = ModemRsp()
+        await modem.coap_receive_data(ctx_id=0, msg_id=1, length=-1, rsp=rsp)
+        self.assert_equal(WalterModemState.ERROR, rsp.result)
+
+    # Method run
+
+    async def test_sends_expected_at_cmd(self):
+        modem.coap_context_states[0].rings.clear()
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"test"',b'OK')
+        await modem.coap_send(0,WalterModemCoapType.CON,WalterModemCoapMethod.GET)
+
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        ring = modem.coap_context_states[0].rings.pop()
+
+        await self.assert_sends_at_command(
+            modem,
+            f'AT+SQNCOAPRCV={ring.ctx_id},{ring.msg_id},512',
+            lambda: modem.coap_receive_data(
+                ctx_id=ring.ctx_id,
+                msg_id=ring.msg_id,
+                length=ring.length,
+                max_bytes=512
+            )
+        )
+    
+    async def test_coap_response_is_set_in_modem_rsp(self):
+        modem.coap_context_states[0].rings.clear()
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"test"',b'OK')
+        await modem.coap_send(0,WalterModemCoapType.CON,WalterModemCoapMethod.GET)
+
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        ring = modem.coap_context_states[0].rings.pop()
+
+        modem_rsp = ModemRsp()
+        await modem.coap_receive_data(
+            ctx_id=ring.ctx_id,
+            msg_id=ring.msg_id,
+            length=ring.length,
+            rsp=modem_rsp
+        )
+        self.assert_is_instance(modem_rsp.coap_rcv_response, ModemCoapResponse)
+        print(f'\n  payload: {modem_rsp.coap_rcv_response.payload}')
+
+class TestCoapReceiveOptions(
+    AsyncTestCase,
+    WalterModemAsserts,
+    NetworkConnectivity
+):
+    async def async_setup(self):
+        await modem.begin() # Modem begin is idempotent
+        await self.ensure_network_connection(modem)
+        self.register_fail_on_cme_error(modem)
+    
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCREATE=0,"coap.me",5683',
+            at_rsp=b'+SQNCOAPCONNECTED: '
+        )
+
+    async def async_teardown(self):
+        self.unregister_fail_on_cme_error(modem)
+        await modem._run_cmd(
+            at_cmd='AT+SQNCOAPCLOSE=0',
+            at_rsp=b'OK'
+        )
+
+    # Context ID range validation
+
+    async def test_fails_below_min_ctx_id(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_options(
+            ctx_id=-1,
+            msg_id=1
+        ))
+
+    async def test_fails_above_max_ctx_id(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_options(
+            ctx_id=3,
+            msg_id=1
+        ))
+
+    async def test_rsp_result_no_such_profile_on_invalid_ctx_id(self):
+        rsp = ModemRsp()
+        await modem.coap_receive_options(ctx_id=7, msg_id=1, rsp=rsp)
+        self.assert_equal(WalterModemState.NO_SUCH_PROFILE, rsp.result)
+
+    # max_options range validation
+
+    async def test_fails_below_min_max_options(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_options(
+            ctx_id=0,
+            msg_id=1,
+            max_options=-1,
+        ))
+
+    async def test_fails_above_max_max_options(self):
+        rsp = ModemRsp()
+        self.assert_false(await modem.coap_receive_options(
+            ctx_id=0,
+            msg_id=1,
+            max_options=33
+        ))
+
+    async def test_rsp_result_error_on_invalid_max_options(self):
+        rsp = ModemRsp()
+        await modem.coap_receive_options(ctx_id=0, msg_id=1, max_options=-1, rsp=rsp)
+        self.assert_equal(WalterModemState.ERROR, rsp.result)
+
+    # Method run
+
+    async def test_sends_expected_at_cmd(self):
+        modem.coap_context_states[0].rings.clear()
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"test"',b'OK')
+        await modem.coap_send(0,WalterModemCoapType.CON,WalterModemCoapMethod.GET)
+
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        ring = modem.coap_context_states[0].rings.pop()
+
+        await self.assert_sends_at_command(
+            modem,
+            f'AT+SQNCOAPRCVO={ring.ctx_id},{ring.msg_id},12',
+            lambda: modem.coap_receive_options(
+                ctx_id=ring.ctx_id,
+                msg_id=ring.msg_id,
+                max_options=12
+            )
+        )
+    
+    async def test_coap_options_is_set_in_modem_rsp(self):
+        modem.coap_context_states[0].rings.clear()
+        await modem._run_cmd('AT+SQNCOAPOPT=0,0,11,"test"',b'OK')
+        await modem.coap_send(0,WalterModemCoapType.CON,WalterModemCoapMethod.GET)
+
+        while len(modem.coap_context_states[0].rings) <= 0:
+            await asyncio.sleep(3)
+        ring = modem.coap_context_states[0].rings.pop()
+
+        modem_rsp = ModemRsp()
+        await modem.coap_receive_options(
+            ctx_id=ring.ctx_id,
+            msg_id=ring.msg_id,
+            rsp=modem_rsp
+        )
+        self.assert_is_instance(modem_rsp.coap_options[0], ModemCoapOption)
+
+testcases = [testcase() for testcase in (
+    TestCoapContextCreate,
+    TestCoapContextClose,
+    TestCoapSetOptions,
+    TestCoapSetHeader,
+    TestCoapSend,
+    TestCoapReceiveData,
+    TestCoapReceiveOptions,
+)]
+
+for testcase in testcases:
+    testcase.run()

--- a/walter_modem/enums.py
+++ b/walter_modem/enums.py
@@ -424,3 +424,102 @@ class WalterModemEDRXMODE(Enum):
     ENABLE_EDRX = 1
     ENABLE_EDRX_AND_UNSOLICITED_RESULT_CODE = 2
     DISABLE_AND_DISCARD_ALL_PARAMS = 3
+
+class WalterModemCoapCloseCause(Enum):
+    """Reason why connection has been closed."""
+    USER = b'USER'
+    SERVER = b'SERVER'
+    NAT_TIMEOUT = b'NAT_TIMEOUT'
+    NETWORK = b'NETWORK'
+
+class WalterModemCoapReqResp(Enum):
+    """Indicator whether a ring is a request from or response from a CoAP seever."""
+    REQUEST = 0
+    RESPONSE = 1
+
+class WalterModemCoapType(Enum):
+    CON = 0
+    NON = 1
+    ACK = 2
+    RST = 3
+
+class WalterModemCoapMethod(Enum):
+    GET = 1
+    POST = 2
+    PUT = 3
+    DELETE = 4
+
+class WalterModemCoapResponseCode(Enum):
+    CREATED = 201
+    DELETED = 202
+    VALID = 203
+    CHANGED = 204
+    CONTENT = 205
+    BAD_REQUEST = 400
+    UNAUTHORIZED = 401
+    BAD_OPTION = 402
+    FORBIDDEN = 403
+    NOT_FOUND = 404
+    METHOD_NOT_ALLOWED = 405
+    NOT_ACCEPTABLE = 406
+    PRECONDITION_FAILED = 412
+    REQUEST_ENTITY_TOO_LARGE = 413
+    UNSUPPORTED_MEDIA_TYPE = 415
+    INERNAL_SERVER_ERROR = 500
+    NOT_IMPLIMENTED = 501
+    BAD_GATEWAY = 502
+    SERVICE_UNAVAILABLE = 503
+    GATEWAY_TIMEOUT = 501
+    PROXYING_NOT_SUPPORTED = 505
+
+class WalterModemCoapOptionAction(Enum):
+    SET = 0
+    DELETE = 1
+    READ = 2
+    EXTEND = 3
+
+class WalterModemCoapOption(Enum):
+    IF_MATCH = 1
+    URI_HOST = 3
+    ETAG = 4
+    IF_NONE_MATCH = 5
+    OBSERVE = 6
+    URI_PORT = 7
+    LOCATION_PATH = 8
+    URI_PATH = 11
+    CONTENT_TYPE = 12
+    MAX_AGE = 14
+    URI_QUERY = 15
+    ACCEPT = 17
+    TOKEN = 19
+    LOCATION_QUERY = 20
+    BLOCK2 = 23
+    BLOCK1 = 27
+    SIZE2 = 28
+    PROXY_URI = 35
+    SIZE1 = 60
+
+class WalterModemCoapContentType(Enum):
+    TEXT_PLAIN = '0'
+    TEXT_XML = '1'
+    TEXT_CSV = '2'
+    TEXT_HTML = '3'
+    IMAGE_GIF = '21'
+    IMAGE_JPEG = '22'
+    IMAGE_PNG = '23'
+    IMAGE_TIFF = '24'
+    AUDIO_RAW = '25'
+    VIDEO_RAW = '26'
+    APPLICATION_LINK_FORMAT = '40'
+    APPLICATION_XML = '41'
+    APPLICATION_OCTET_STREAM = '42'
+    APPLICATION_RDF_XML = '43'
+    APPLICATION_SOAP_XML = '44'
+    APPLICATION_ATOM_XML = '45'
+    APPLICATION_XMPP_XML = '46'
+    APPLICATION_EXI = '47'
+    APPLICATION_FASTINFOSET = '48'
+    APPLICATION_SOAP_FASTINFOSET = '49'
+    APPLICATION_JSON = '50'
+    APPLICATION_X_OBIX_BINARY = '51'
+    APPLICATION_CBOR = '60'

--- a/walter_modem/mixins/__init__.py
+++ b/walter_modem/mixins/__init__.py
@@ -7,3 +7,4 @@ from .socket import ModemSocket
 from .http import ModemHTTP
 from .mqtt import ModemMQTT
 from .sleep import ModemSleep
+from .coap import ModemCoap

--- a/walter_modem/mixins/coap.py
+++ b/walter_modem/mixins/coap.py
@@ -1,0 +1,365 @@
+from ..core import ModemCore
+from ..enums import (
+    WalterModemState,
+    WalterModemCmdType,
+    WalterModemCoapType,
+    WalterModemCoapMethod,
+    WalterModemCoapOption,
+    WalterModemCoapOptionAction,
+    WalterModemCoapContentType
+)
+from ..structs import (
+    ModemRsp,
+)
+from ..utils import (
+    modem_bool,
+    modem_string
+)
+
+COAP_REPEATABLE_OPTIONS = (
+    WalterModemCoapOption.IF_MATCH,
+    WalterModemCoapOption.ETAG,
+    WalterModemCoapOption.LOCATION_PATH,
+    WalterModemCoapOption.URI_PATH,
+    WalterModemCoapOption.URI_QUERY,
+    WalterModemCoapOption.LOCATION_QUERY
+)
+
+COAP_HEADER_MAX_TOKEN_STR_LEN = 16
+COAP_MIN_MSG_ID = 0
+COAP_MAX_MSG_ID = 65535
+COAP_RECVO_MAX_OPTS = 32
+COAP_RECVO_MIN_OPTS = 0
+
+
+class ModemCoap(ModemCore):
+    async def coap_context_create(self,
+        ctx_id: int,
+        server_address: str = None,
+        server_port: int = None,
+        local_port: int = None,
+        timeout: int = 20,
+        dtls: bool = False,
+        secure_profile_id: int = None,
+        rsp: ModemRsp = None
+    ) -> bool:
+        """
+        Create a CoAP context, required to send, receive & set CoAP options.
+
+        If the server_address & server_port are provided, a connection attempt is made.
+
+        If server_address & server_port are omitted and only local_port is provided,
+        the context is created in listen mode, waiting for an incoming connection.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param server_address: IP addr/hostname of the CoAP server.
+        :param server_port: The UDP remote port of the CoAP server;
+        :param local_port: The UDP local port, if omitted, a randomly available port is assigned
+        (recommended)
+        :param timeout: The time (in seconds) to wait for a response from the CoAP server
+        before aborting: 1-120. (independent of the ACK_TIMEOUT used for retransmission)
+        :param dtls: Whether or not to use DTLS encryption
+        :param secure_profile_id: The SSL/TLS security profile configuration (ID) to use.
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+
+        if timeout < ModemCore.COAP_MIN_TIMEOUT or ModemCore.COAP_MAX_TIMEOUT < timeout:
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+
+        async def complete_handler(result, rsp, complete_handler_arg):
+            if result == WalterModemState.OK:
+                self.coap_context_states[complete_handler_arg].connected = True
+
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd='AT+SQNCOAPCREATE={},{},{},{},{},{}{}'.format(
+                ctx_id,
+                modem_string(server_address) if server_address else '',
+                server_port if server_port else '',
+                local_port if local_port else '',
+                modem_bool(dtls),
+                timeout,
+                f',,{secure_profile_id}' if secure_profile_id else ''
+            ),
+            at_rsp=(b'+SQNCOAPCONNECTED:', b'+SQNCOAP: ERROR'),
+            complete_handler=complete_handler,
+            complete_handler_arg=ctx_id
+        )
+
+    async def coap_context_close(self,
+        ctx_id: int,
+        rsp: ModemRsp = None
+    ) -> bool:
+        """
+        Close a CoAP context.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd=f'AT+SQNCOAPCLOSE={ctx_id}',
+            at_rsp=b'OK'
+        )
+
+    async def coap_set_options(self,
+        ctx_id: int,
+        action: WalterModemCoapOptionAction,
+        option: WalterModemCoapOption,
+        value: str | WalterModemCoapContentType | tuple[str] = None,
+        rsp: ModemRsp = None,
+    ) -> bool:
+        """
+        Configure CoAP options for the next message to be sent.
+        Options are to be configured one at a time.
+        For repeatable options, up to 6 values can be provided (the order is respected).
+        The repeatable options are:
+        IF_MATCH, ETAG, LOCATION_PATH, LOCATION_PATH, URI_PATH, URI_QUERY, LOCATION_QUERY
+
+        The values are to be passed along as extra params.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param action: Action to perform
+        :type action: WalterModemCoapOptionAction
+        :param option: The option to perform the action on
+        :type option: WalterModemCoapOption
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+        
+        if isinstance(value, tuple):
+            if len(value) > 0 and option not in COAP_REPEATABLE_OPTIONS:
+                if rsp: rsp.result = WalterModemState.ERROR
+                return False
+
+            if len(value) > 6:
+                if rsp: rsp.result = WalterModemState.ERROR
+                return False
+
+            value = ','.join(modem_string(v) for v in value)
+        else:
+            value = modem_string(value)
+        
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd='AT+SQNCOAPOPT={},{},{}{}'.format(
+                ctx_id, action, option,
+                f',{value}' if value != None else ''
+            ),
+            at_rsp=b'OK'
+        )
+    
+    async def coap_set_header(self,
+        ctx_id: int,
+        msg_id: int = None,
+        token: str = None,
+        rsp: ModemRsp = None
+    ) -> bool:
+        """
+        Configure the coap header for the next message to be sent
+
+        If only msg_id is set, the CoAP client sets a random token value.
+        If only token is set, the CoAP client sets a random msg_id value.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param msg_id: Message ID of the CoAP header (0-65535)
+        :param token: hexidecimal format, token to be used in the CoAP header,
+        specify: "NO_TOKEN" for a header without token.
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+        
+        if msg_id != None and (msg_id < COAP_MIN_MSG_ID or COAP_MAX_MSG_ID < msg_id):
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        if token != None:
+            if COAP_HEADER_MAX_TOKEN_STR_LEN < len(token):
+                if rsp: rsp.result = WalterModemState.ERROR
+                return False
+            
+            if token != 'NO_TOKEN':
+                try:
+                    int(token, 16)
+                except ValueError:
+                    if rsp: rsp.result = WalterModemState.ERROR
+                    return False
+        
+        await self._run_cmd(
+            rsp=rsp,
+            at_cmd=f'AT+SQNCOAPHDR={ctx_id},{msg_id},{modem_string(token) if token != None else ''}',
+            at_rsp=b'OK'
+        )
+    
+    async def coap_send(self,
+        ctx_id: int,
+        m_type: WalterModemCoapType,
+        method: WalterModemCoapMethod,
+        data: bytes | bytearray | str | None = None,
+        length: int = None,
+        path: str = None,
+        content_type: WalterModemCoapContentType = None,
+        rsp: ModemRsp = None,
+    ) -> bool:
+        """
+        Send data over CoAP, if no data is sent, length must be set to zero.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param m_type: CoAP message type
+        :type m_type: WalterModemCoapType
+        :param method: method (GET, POST, PUT, DELETE)
+        :type method: WalterModemCoapMethod
+        :param data: Binary data to send (bytes, bytearray) or string (will be UTF-8 encoded)
+        :param length: Length of the payload (optional, auto-calculated if not provided)
+        :param path: Optional, the URI_PATH to send on,
+        this will set the path in the CoAP options before sending
+        :param content_type: Optional, the content_type,
+        this will set the content type in the CoAP options before sending
+        :type content_type: WalterModemCoapContentType
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+        
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        elif data is not None and not isinstance(data, (bytes, bytearray)):
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        if length is None:
+            length = 0 if data is None else len(data)
+        
+        if length < ModemCore.COAP_MIN_BYTES_LENGTH or ModemCore.COAP_MAX_BYTES_LENGTH < length:
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        if path is not None:
+            path_parts = path.strip('/').split('/')
+
+            while len(path_parts) > 0:
+                if not await self.coap_set_options(
+                    ctx_id=ctx_id,
+                    action=WalterModemCoapOptionAction.SET,
+                    option=WalterModemCoapOption.URI_PATH,
+                    value=tuple(path_parts[:6]),
+                    rsp=rsp
+                ):
+                    return False
+                path_parts[:6] = []
+        
+        if isinstance(content_type, WalterModemCoapContentType):
+            if not await self.coap_set_options(
+                ctx_id=ctx_id,
+                action=WalterModemCoapOptionAction.SET,
+                option=WalterModemCoapOption.CONTENT_TYPE,
+                value=content_type,
+                rsp=rsp
+            ):
+                return False
+        
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd=f'AT+SQNCOAPSEND={ctx_id},{m_type},{method},{length}',
+            at_rsp=b'OK',
+            data=data,
+            cmd_type=WalterModemCmdType.DATA_TX_WAIT
+        )
+    
+    async def coap_receive_data(self,
+        ctx_id: int,
+        msg_id: int,
+        length: int,
+        max_bytes = 1024,
+        rsp: ModemRsp = None
+    ) -> bool:
+        """
+        Read the contents of a CoAP message after it's ring has been received.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param msg_id: CoAP message id
+        :param length: The length of the payload to receive (the length of the ring)
+        :param max_bytes: How many bytes of the message to payload to read at once
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+
+        if max_bytes < ModemCore.COAP_MIN_BYTES_LENGTH or ModemCore.COAP_MAX_BYTES_LENGTH < max_bytes:
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        if length < 0:
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        self._parser_data.raw_chunk_size = min(length, max_bytes)
+        
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd=f'AT+SQNCOAPRCV={ctx_id},{msg_id},{max_bytes}',
+            at_rsp=b'OK'
+        )
+    
+    async def coap_receive_options(self,
+        ctx_id: int,
+        msg_id: int,
+        max_options = 32,
+        rsp: ModemRsp = None
+    ) -> bool:
+        """
+        Read the options of a CoAP message after it's ring has been received.
+
+        :param ctx_id: Context profile identifier (0, 1, 2)
+        :param msg_id: CoAP message id
+        :param max_options: The maximum options that can be shown in the response (0-32)
+        :param rsp: Reference to a modem response instance
+
+        :return bool: True on success, False on failure     
+        """
+
+        if ctx_id < ModemCore.COAP_MIN_CTX_ID or ModemCore.COAP_MAX_CTX_ID < ctx_id:
+            if rsp: rsp.result = WalterModemState.NO_SUCH_PROFILE
+            return False
+        
+        if max_options < COAP_RECVO_MIN_OPTS or COAP_RECVO_MAX_OPTS < max_options:
+            if rsp: rsp.result = WalterModemState.ERROR
+            return False
+        
+        return await self._run_cmd(
+            rsp=rsp,
+            at_cmd=f'AT+SQNCOAPRCVO={ctx_id},{msg_id},{max_options}',
+            at_rsp=b'OK'
+        )

--- a/walter_modem/modem.py
+++ b/walter_modem/modem.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 
 from machine import ( # type: ignore
     UART,
@@ -30,12 +29,16 @@ class Modem(
     mixins.ModemSocket,
     mixins.ModemMQTT,
     mixins.ModemHTTP,
+    mixins.ModemCoap,
     mixins.ModemSleep
 ):
     def __init__(self):
         ModemCore.__init__(self)
 
-    async def begin(self, debug_log: bool = False):
+    async def begin(self,
+        debug_log: bool = False,
+        _dev_debug_uart_reader = False
+    ):
         if not self._begun:
             self.debug_log = debug_log
             self._uart = UART(2,
@@ -60,7 +63,10 @@ class Modem(
             self._command_queue = Queue()
             self._parser_data = ModemATParserData()
 
-            self._uart_reader_task = asyncio.create_task(self._uart_reader())
+            if _dev_debug_uart_reader:
+                self._uart_reader_task = asyncio.create_task(self._dev_debug_uart_reader())
+            else:
+                self._uart_reader_task = asyncio.create_task(self._uart_reader())
             self._queue_worker_task = asyncio.create_task(self._queue_worker())
 
             

--- a/walter_modem/structs.py
+++ b/walter_modem/structs.py
@@ -17,7 +17,13 @@ from .enums import (
     WalterModemSocketProto,
     WalterModemSocketState,
     WalterModemState,
-    WalterModemMqttResultCode
+    WalterModemMqttResultCode,
+    WalterModemCoapCloseCause,
+    WalterModemCoapReqResp,
+    WalterModemCoapType,
+    WalterModemCoapMethod,
+    WalterModemCoapResponseCode,
+    WalterModemCoapOption
 )
 
 
@@ -215,6 +221,13 @@ class ModemRsp:
 
         self.cell_information: ModemCellInformation | None = None
 
+        self.coap_rcv_response: ModemCoapResponse | None = None
+        """The CoAP response from receiving ring data (coap_receive_data)"""
+
+        self.coap_options: ModemCoapOption | list[ModemCoapOption] | None = None
+        """The CoAP options either from receiving a ring options (coap_receive_options)
+        or from the READ action in coap_set_options"""
+
 class ModemMqttMessage:
     def __init__(self, topic, length, qos, message_id = None, payload = None):
         self.topic = topic
@@ -408,3 +421,50 @@ class ModemCellInformation:
 
         self.ce_level: int = 0
         """Coverage Enhancement Level"""
+    
+class ModemCoapContextState:
+    def __init__(self):
+        self.connected: bool = False
+        """Whether or not the coap profile is connected or listening."""
+
+        self.cause: None | WalterModemCoapCloseCause = None
+        """If connection lost/disconnected; the reason why"""
+
+        self.rings: list[ModemCoapRing] = []
+        """List of coap rings, errornous rings are ignored"""
+
+    @property
+    def configured(self):
+        """
+        Whether or not the coap profile has been configured yet.
+        Note, the context configuration is lost on disconnect.
+        """
+        return self.connected
+
+class ModemCoapRing:
+    def __init__(self, ctx_id, msg_id, req_resp, m_type, method, rsp_code, length):
+        self.ctx_id: int = ctx_id
+        self.msg_id: int = msg_id
+        self.req_resp: WalterModemCoapReqResp = req_resp
+        self.type: WalterModemCoapType = m_type
+        self.method: WalterModemCoapMethod | None = method
+        self.rsp_code: WalterModemCoapResponseCode | None = rsp_code
+        self.length: int = length
+
+class ModemCoapResponse:
+    def __init__(self, ctx_id, msg_id, token, req_resp, m_type, method, rsp_code, length, payload):
+        self.ctx_id: int = ctx_id
+        self.msg_id: int = msg_id
+        self.token: str = token
+        self.req_resp: int = req_resp
+        self.type: WalterModemCoapType = m_type
+        self.method: WalterModemCoapMethod | None = method
+        self.rsp_code: WalterModemCoapResponseCode | None = rsp_code
+        self.length: int = length
+        self.payload: bytearray = payload
+
+class ModemCoapOption:
+    def __init__(self, ctx_id, option, value):
+        self.ctx_id: int = ctx_id,
+        self.option: WalterModemCoapOption = option,
+        self.value: str = value


### PR DESCRIPTION
Implements:

- `coap_context_create`
- `coap_context_close`
- `coap_set_options`
- `coap_set_header`
- `coap_send`
- `coap_receive_data`
- `coap_receive_options`

All methods attempt to reflect the Sequans modem's abilities to the fullest.\
All methods are thoroughly tested and debugged: `tests/modem_library/test_coap.py`