### PR TITLE
Modem MQTT, minor bugfixes

### DIFF
--- a/tests/modem_library/test_deepsleep_mqtt_persist.py
+++ b/tests/modem_library/test_deepsleep_mqtt_persist.py
@@ -16,13 +16,6 @@ from walter_modem.structs import (
 modem = Modem()
 modem_rsp = ModemRsp()
 
-# NOTE: Minimal deepsleep testing
-# ===============================
-# Most of the deepsleep testing has to be done manually
-# Measuring power, expected modem behaviour, ...
-# That said, said this testfile aids in that testing,
-# as it only runs again after pressing the reset button.
-
 async def await_connection():
         print('\nShowing modem debug logs:')
         modem.debug_log = True
@@ -38,14 +31,14 @@ async def await_connection():
         modem.debug_log = False
         raise OSError('Connection Timed-out')
 
-class TestDeepSleep(unittest.AsyncTestCase):
+class TestDeepSleepMqttPersist(unittest.AsyncTestCase):
     async def async_setup(self):
         print(f'Started, reason: {machine.reset_cause()}')
         await asyncio.sleep(3)
         print('Second startup notice (3s after startup)')
-
+        await modem.begin()
+        
         if machine.reset_cause() != machine.DEEPSLEEP_RESET:
-            await modem.begin()
             await modem.create_PDP_context()
             await modem.get_op_state(rsp=modem_rsp)
             if modem_rsp.op_state is not WalterModemOpState.FULL:
@@ -53,16 +46,20 @@ class TestDeepSleep(unittest.AsyncTestCase):
 
             await await_connection()
             print('Network Connection established')
+            await modem.mqtt_config()
+            print('connecting to MQTT')
+            await modem.mqtt_connect(server_name='test.mosquitto.org', port=1883)
+            print('setting MQTT subscriptions')
+            await modem.mqtt_subscribe(topic='short', qos=1)
+            await modem.mqtt_subscribe(topic='long-topic-test', qos=0)
+            print(modem._mqtt_subscriptions)
             print('Waiting 5sec before entering deepsleep')
             await asyncio.sleep(5)
             print('Starting 20s deepsleep')
-            modem.sleep(sleep_time_ms=20000)
+            modem.sleep(sleep_time_ms=20000, persist_mqtt_subs=True)
+        
+    async def test_mqtt_subscriptions_persist_after_deepsleep(self):
+        self.assert_equal([('short', 1), ('long-topic-test', 0)], modem._mqtt_subscriptions)
 
-    async def test_modem_begins_after_deepsleep(self):
-        await self.assert_does_not_throw(modem.begin, Exception)
-    
-    async def test_modem_retained_connection_during_sleep(self):
-        self.assert_equal(WalterModemOpState.FULL, modem._op_state)
-
-test_deep_sleep = TestDeepSleep()
-test_deep_sleep.run()
+test_deep_sleep_mqtt_persist = TestDeepSleepMqttPersist()
+test_deep_sleep_mqtt_persist.run()

--- a/walter_modem/core.py
+++ b/walter_modem/core.py
@@ -607,7 +607,7 @@ class ModemCore:
         return WalterModemState.OK
     
     async def _handle_sqns_mqtt_subscribe(self, tx_stream, cmd, at_rsp):
-        result_code = int(at_rsp[-2:].strip(b','))
+        result_code = int(at_rsp[-2:].strip(b',').decode())
 
         if cmd and cmd.at_cmd:
             cmd.rsp.type = WalterModemRspType.MQTT

--- a/walter_modem/enums.py
+++ b/walter_modem/enums.py
@@ -280,7 +280,7 @@ class WalterModemHttpContextState(Enum):
 
 class WalterModemMqttState(Enum):
     CONNECTED = 0
-    DISCONNECTED = 0
+    DISCONNECTED = 1
 
 class WalterModemMqttResultCode(Enum):
     SUCCESS = 0


### PR DESCRIPTION
- WalterModemMqttState enum values should be different
- Decode result code before parsing to an int
- Seperate mqqt subscription persistance test from deepsleep test