### PR TITLE
Fix: assert_sends_at_command misses first sent command

### DIFF
--- a/tests/minimal_unittest.py
+++ b/tests/minimal_unittest.py
@@ -357,6 +357,7 @@ class WalterModemAsserts:
 
                 if cmd is not None: sent_cmd = cmd.at_cmd
                 if b'ERROR' in at_rsp: error = True
+                modem_instance.unregister_application_queue_rsp_handler(cmd_handler)
 
             modem_instance.register_application_queue_rsp_handler(at_rsp_pattern, cmd_handler)
             modem_instance.register_application_queue_rsp_handler(b'ERROR', cmd_handler)
@@ -367,7 +368,6 @@ class WalterModemAsserts:
             for _ in range(timeout_s):
                 if sent_cmd is not None: break
                 await asyncio.sleep(3)
-            modem_instance.unregister_application_queue_rsp_handler(cmd_handler)
 
             if error:
                 self.failed += 1


### PR DESCRIPTION
Unregister the application queue rsp handler immediately after the cmd_handler is done.

Closes #42 