### PR TITLE
Fix: resetting mirrorstate resets begun flag

### DIFF
--- a/walter_modem/mixins/common.py
+++ b/walter_modem/mixins/common.py
@@ -29,6 +29,7 @@ class ModemCommon(ModemCore):
         self._reset_pin.init(hold=True)
 
         super().__init__() # Reset internal mirror state
+        self._begun = True # Keep begin idempotent
 
         return await self._run_cmd(
             rsp=rsp,
@@ -49,6 +50,7 @@ class ModemCommon(ModemCore):
 
         if cmd_result:
             super().__init__() # Reset internal mirror state
+            self._begun = True # Keep begin idempotent
         
         return cmd_result
     


### PR DESCRIPTION
Set self._begun true after calling super init.

Closes #44 