### PR TITLE
Fix: inconsistent method naming

### DIFF
--- a/examples/counter/boot.py
+++ b/examples/counter/boot.py
@@ -180,14 +180,14 @@ async def setup():
         return False
    
     print('Creating socket')
-    if await modem.create_socket(rsp=modem_rsp):
+    if await modem.socket_create(rsp=modem_rsp):
         socket_id = modem_rsp.socket_id
     else:
         print('Failed to create socket')
         return False
     
     print('Connecting socket')
-    if not await modem.connect_socket(
+    if not await modem.socket_connect(
         remote_host=config.SERVER_ADDRESS,
         remote_port=config.SERVER_PORT,
         local_port=config.SERVER_PORT,

--- a/examples/counter/boot.py
+++ b/examples/counter/boot.py
@@ -161,14 +161,14 @@ async def setup():
     if config.SIM_PIN != None and not await unlock_sim():
         return False
     
-    if not await modem.create_PDP_context(
+    if not await modem.pdp_context_create(
         apn=config.CELL_APN,
         rsp=modem_rsp
     ):
         print('Failed to create socket')
         return False
    
-    if config.APN_USERNAME and not await modem.set_PDP_auth_params(
+    if config.APN_USERNAME and not await modem.pdp_set_auth_params(
         protocol=config.AUTHENTICATION_PROTOCOL,
         user_id=config.APN_USERNAME,
         password=config.APN_PASSWORD

--- a/examples/mqtt/boot.py
+++ b/examples/mqtt/boot.py
@@ -157,14 +157,14 @@ async def setup():
     if config.SIM_PIN != None and not await unlock_sim():
         return False
     
-    if not await modem.create_PDP_context(
+    if not await modem.pdp_context_create(
         apn=config.CELL_APN,
         rsp=modem_rsp
     ):
         print('Failed to create socket')
         return False
    
-    if config.APN_USERNAME and not await modem.set_PDP_auth_params(
+    if config.APN_USERNAME and not await modem.pdp_set_auth_params(
         protocol=config.AUTHENTICATION_PROTOCOL,
         user_id=config.APN_USERNAME,
         password=config.APN_PASSWORD

--- a/examples/positioning/boot.py
+++ b/examples/positioning/boot.py
@@ -238,7 +238,7 @@ def check_assistance_data() -> tuple[bool, bool]:
 
 async def gnss_assistance_update() -> bool:
     """
-    This function will update GNNS assistance data when needed.
+    This function will update GNSS assistance data when needed.
 
     Check if the current real-time ephemeris data is good enough to get a fast GNSS fix.
     If not, the function will connect to the LTE network to download newer assistance data.
@@ -342,7 +342,7 @@ async def setup():
         print('Failed to create socket')
         return False
     
-    if not await modem.gnns_config():
+    if not await modem.gnss_config():
         print('Failed to configure GNSS subsystem')
         return False
     

--- a/examples/positioning/boot.py
+++ b/examples/positioning/boot.py
@@ -236,7 +236,7 @@ def check_assistance_data() -> tuple[bool, bool]:
 
     return update_almanac, update_ephemeris
 
-async def update_gnss_assistance() -> bool:
+async def gnss_assistance_update() -> bool:
     """
     This function will update GNNS assistance data when needed.
 
@@ -270,7 +270,7 @@ async def update_gnss_assistance() -> bool:
 
         await asyncio.sleep(.5)
 
-    if not await modem.get_gnss_assistance_status(rsp=modem_rsp):
+    if not await modem.gnss_assistance_get_status(rsp=modem_rsp):
         if modem_rsp.type != WalterModemRspType.GNSS_ASSISTANCE_DATA:
             print('  - Failed to request GNSS assistance status')
             return False
@@ -283,7 +283,7 @@ async def update_gnss_assistance() -> bool:
             print('  - Failed to connect to LTE network')
             return False
         
-        if not await modem.update_gnss_assistance(WalterModemGNSSAssistanceType.ALMANAC):
+        if not await modem.gnss_assistance_update(WalterModemGNSSAssistanceType.ALMANAC):
             print('  - Failed to update almanac data')
             return False
         
@@ -293,7 +293,7 @@ async def update_gnss_assistance() -> bool:
             print('  - Failed to connect to LTE network')
             return False
         
-        if not await modem.update_gnss_assistance(WalterModemGNSSAssistanceType.REALTIME_EPHEMERIS):
+        if not await modem.gnss_assistance_update(WalterModemGNSSAssistanceType.REALTIME_EPHEMERIS):
             print('  - Failed to update ephemeris data')
             return False
         
@@ -342,7 +342,7 @@ async def setup():
         print('Failed to create socket')
         return False
     
-    if not await modem.config_gnss():
+    if not await modem.gnns_config():
         print('Failed to configure GNSS subsystem')
         return False
     
@@ -352,7 +352,7 @@ async def loop():
     global modem_rsp
 
     print('Checking GNSS assistance data...')
-    if not await update_gnss_assistance():
+    if not await gnss_assistance_update():
         print('Failed to update GNSS assistance data')
 
     print('Attempting to request a GNSS fix')
@@ -362,7 +362,7 @@ async def loop():
             print(f'  - trying again, run: {i+1}/5')
         await lte_disconnect()
 
-        if not await modem.perform_gnss_action(
+        if not await modem.gnss_perform_action(
             action=WalterModemGNSSAction.GET_SINGLE_FIX,
             rsp=modem_rsp
         ):
@@ -372,7 +372,7 @@ async def loop():
 
         print('  - Requested GNSS fix')
         print('  - Waiting for GNSS fix')
-        gnss_fix = await modem.wait_for_gnss_fix()
+        gnss_fix = await modem.gnss_wait_for_fix()
 
         if gnss_fix.estimated_confidence <= config.MAX_GNSS_CONFIDENCE:
             print(f'  - Fix success, estimated confidence: {gnss_fix.estimated_confidence}')

--- a/examples/positioning/boot.py
+++ b/examples/positioning/boot.py
@@ -317,14 +317,14 @@ async def setup():
     if config.SIM_PIN != None and not await unlock_sim():
         return False
     
-    if not await modem.create_PDP_context(
+    if not await modem.pdp_context_create(
         apn=config.CELL_APN,
         rsp=modem_rsp
     ):
         print('Failed to create socket')
         return False
    
-    if config.APN_USERNAME and not await modem.set_PDP_auth_params(
+    if config.APN_USERNAME and not await modem.pdp_set_auth_params(
         protocol=config.AUTHENTICATION_PROTOCOL,
         user_id=config.APN_USERNAME,
         password=config.APN_PASSWORD

--- a/examples/positioning/boot.py
+++ b/examples/positioning/boot.py
@@ -164,7 +164,7 @@ async def lte_transmit(socket_id: int, address: str, port: int, buffer: bytearra
 
     :return bool: True on success, False on failure
     """
-    if not await modem.connect_socket(
+    if not await modem.socket_connect(
         remote_host=address,
         remote_port=port,
         socket_id=socket_id,
@@ -183,7 +183,7 @@ async def lte_transmit(socket_id: int, address: str, port: int, buffer: bytearra
         print('  - Failed to transmit to UDP socket')
         return False
     
-    if not await modem.close_socket(
+    if not await modem.socket_close(
         socket_id=socket_id
     ):
         print('  - Failed to close UDP socket')
@@ -336,7 +336,7 @@ async def setup():
         return False
    
     print('Creating socket')
-    if await modem.create_socket(rsp=modem_rsp):
+    if await modem.socket_create(rsp=modem_rsp):
         socket_id = modem_rsp.socket_id
     else:
         print('Failed to create socket')

--- a/examples/walter_feels/boot.py
+++ b/examples/walter_feels/boot.py
@@ -244,7 +244,7 @@ async def modem_setup():
     if config.SIM_PIN != None and not await unlock_sim():
         return False
     
-    if not await modem.create_PDP_context(
+    if not await modem.pdp_context_create(
         apn=config.CELL_APN,
         rsp=modem_rsp
     ):
@@ -253,7 +253,7 @@ async def modem_setup():
     
     wdt.feed()
    
-    if config.APN_USERNAME and not await modem.set_PDP_auth_params(
+    if config.APN_USERNAME and not await modem.pdp_set_auth_params(
         protocol=config.AUTHENTICATION_PROTOCOL,
         user_id=config.APN_USERNAME,
         password=config.APN_PASSWORD

--- a/tests/modem_library/test_deepsleep.py
+++ b/tests/modem_library/test_deepsleep.py
@@ -46,7 +46,7 @@ class TestDeepSleep(unittest.AsyncTestCase):
 
         if machine.reset_cause() != machine.DEEPSLEEP_RESET:
             await modem.begin()
-            await modem.create_PDP_context()
+            await modem.pdp_context_create()
             await modem.get_op_state(rsp=modem_rsp)
             if modem_rsp.op_state is not WalterModemOpState.FULL:
                 await modem.set_op_state(WalterModemOpState.FULL)

--- a/tests/modem_library/test_deepsleep_mqtt_persist.py
+++ b/tests/modem_library/test_deepsleep_mqtt_persist.py
@@ -39,7 +39,7 @@ class TestDeepSleepMqttPersist(unittest.AsyncTestCase):
         await modem.begin()
         
         if machine.reset_cause() != machine.DEEPSLEEP_RESET:
-            await modem.create_PDP_context()
+            await modem.pdp_context_create()
             await modem.get_op_state(rsp=modem_rsp)
             if modem_rsp.op_state is not WalterModemOpState.FULL:
                 await modem.set_op_state(WalterModemOpState.FULL)

--- a/tests/modem_library/test_gnss.py
+++ b/tests/modem_library/test_gnss.py
@@ -74,7 +74,7 @@ class TestGNSSConfig(
             )
         )
 
-class TestGNNSAssistanceGetStatus(
+class TestGNSSAssistanceGetStatus(
     AsyncTestCase,
     WalterModemAsserts
 ):
@@ -107,7 +107,7 @@ class TestGNNSAssistanceGetStatus(
 
         self.assert_equal(WalterModemRspType.GNSS_ASSISTANCE_DATA, modem_rsp.type)
 
-class TestGNNSAssistanceUpdate(
+class TestGNSSAssistanceUpdate(
     AsyncTestCase,
     WalterModemAsserts,
     NetworkConnectivity
@@ -167,7 +167,7 @@ class TestGNSSPerformAction(
         await modem._run_cmd('AT+CFUN=0', b'OK')
 
     async def async_teardown(self):
-        # Ensure no gnns action is still running
+        # Ensure no gnss action is still running
         await modem._run_cmd(
             at_cmd='AT+LPGNSSFIXPROG="stop"',
             at_rsp=b'OK'
@@ -218,8 +218,8 @@ class TestGNSSWaitForFix(
 
 testcases = [testcase() for testcase in (
     TestGNSSConfig,
-    TestGNNSAssistanceGetStatus,
-    TestGNNSAssistanceUpdate,
+    TestGNSSAssistanceGetStatus,
+    TestGNSSAssistanceUpdate,
     TestGNSSPerformAction,
     TestGNSSWaitForFix,
 )]

--- a/tests/modem_library/test_gnss.py
+++ b/tests/modem_library/test_gnss.py
@@ -24,7 +24,7 @@ from walter_modem.structs import (
 
 modem = Modem()
 
-class TestConfigGNNS(
+class TestGNSSConfig(
     AsyncTestCase,
     WalterModemAsserts
 ):
@@ -32,32 +32,32 @@ class TestConfigGNNS(
         await modem.begin() # Modem begin is idempotent
     
     async def async_teardown(self):
-        await modem.config_gnss() # Restore back to library defaults
+        await modem.gnss_config() # Restore back to library defaults
     
     # Test fail on invalid param
 
     async def test_fails_on_invalid_sens_mode(self):
-        self.assert_false(await modem.config_gnss(sens_mode=-70))
+        self.assert_false(await modem.gnss_config(sens_mode=-70))
 
     async def test_fails_on_invalid_acq_mode(self):
-        self.assert_false(await modem.config_gnss(acq_mode=-70))
+        self.assert_false(await modem.gnss_config(acq_mode=-70))
 
     async def test_fails_on_invalid_loc_mode(self):
-        self.assert_false(await modem.config_gnss(acq_mode=-70))
+        self.assert_false(await modem.gnss_config(acq_mode=-70))
     
     async def test_cme_50_set_in_modem_rsp_on_invalid_param(self):
         modem_rsp = ModemRsp()
-        await modem.config_gnss(-70, -60, -50, modem_rsp)
+        await modem.gnss_config(-70, -60, -50, modem_rsp)
 
         self.assert_equal(WalterModemCMEError.INCORRECT_PARAMETERS, modem_rsp.cme_error)
 
     # Test normal run
 
     async def test_returns_true_on_no_params(self):
-        self.assert_true(await modem.config_gnss())
+        self.assert_true(await modem.gnss_config())
 
     async def test_returns_true_on_valid_params(self):
-        self.assert_true(await modem.config_gnss(
+        self.assert_true(await modem.gnss_config(
             sens_mode=WalterModemGNSSSensMode.LOW,
             acq_mode=WalterModemGNSSAcqMode.HOT_START,
             loc_mode=WalterModemGNSSLocMode.ON_DEVICE_LOCATION
@@ -67,14 +67,14 @@ class TestConfigGNNS(
         await self.assert_sends_at_command(
             modem,
             'AT+LPGNSSCFG=0,2,2,,1,0',
-            lambda: modem.config_gnss(
+            lambda: modem.gnss_config(
                 sens_mode=WalterModemGNSSSensMode.MEDIUM,
                 acq_mode=WalterModemGNSSAcqMode.COLD_WARM_START,
                 loc_mode=WalterModemGNSSLocMode.ON_DEVICE_LOCATION
             )
         )
 
-class TestGetGNNSAssistanceStatus(
+class TestGNNSAssistanceGetStatus(
     AsyncTestCase,
     WalterModemAsserts
 ):
@@ -86,28 +86,28 @@ class TestGetGNNSAssistanceStatus(
         self.unregister_fail_on_cme_error(modem)
     
     async def test_returns_true(self):
-        self.assert_true(await modem.get_gnss_assistance_status())
+        self.assert_true(await modem.gnss_assistance_get_status())
     
     async def test_sends_expected_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             'AT+LPGNSSASSISTANCE?',
-            lambda: modem.get_gnss_assistance_status()
+            lambda: modem.gnss_assistance_get_status()
         )
 
     async def test_gnss_assistance_set_in_modem_rsp(self):
         modem_rsp = ModemRsp()
-        await modem.get_gnss_assistance_status(rsp=modem_rsp)
+        await modem.gnss_assistance_get_status(rsp=modem_rsp)
         
         self.assert_is_instance(modem_rsp.gnss_assistance, ModemGNSSAssistance)
     
     async def test_type_set_to_gnss_assistance_data_in_modem_rsp(self):
         modem_rsp = ModemRsp()
-        await modem.get_gnss_assistance_status(rsp=modem_rsp)
+        await modem.gnss_assistance_get_status(rsp=modem_rsp)
 
         self.assert_equal(WalterModemRspType.GNSS_ASSISTANCE_DATA, modem_rsp.type)
 
-class TestUpdateGNNSAssistance(
+class TestGNNSAssistanceUpdate(
     AsyncTestCase,
     WalterModemAsserts,
     NetworkConnectivity
@@ -119,21 +119,21 @@ class TestUpdateGNNSAssistance(
     # Test fail on invalid param
 
     async def test_fails_on_invalid_type(self):
-        self.assert_false(await modem.update_gnss_assistance(type=-3))
+        self.assert_false(await modem.gnss_assistance_update(type=-3))
 
     async def test_cme_50_set_in_modem_rsp_on_invalid_param(self):
         modem_rsp = ModemRsp()
-        await modem.update_gnss_assistance(type=-3, rsp=modem_rsp)
+        await modem.gnss_assistance_update(type=-3, rsp=modem_rsp)
 
         self.assert_equal(WalterModemCMEError.INCORRECT_PARAMETERS, modem_rsp.cme_error)
 
     # Test normal run
 
     async def test_returns_true_on_no_param(self):
-        self.assert_true(await modem.update_gnss_assistance())
+        self.assert_true(await modem.gnss_assistance_update())
 
     async def test_returns_true_on_valid_param(self):
-        self.assert_true(await modem.update_gnss_assistance(
+        self.assert_true(await modem.gnss_assistance_update(
             type=WalterModemGNSSAssistanceType.REALTIME_EPHEMERIS
         ))
 
@@ -141,12 +141,12 @@ class TestUpdateGNNSAssistance(
         await self.assert_sends_at_command(
             modem,
             'AT+LPGNSSASSISTANCE=1',
-            lambda: modem.update_gnss_assistance(
+            lambda: modem.gnss_assistance_update(
                 type=WalterModemGNSSAssistanceType.REALTIME_EPHEMERIS
             )
         )
 
-class TestPerformGNSSAction(
+class TestGNSSPerformAction(
     AsyncTestCase,
     WalterModemAsserts,
     NetworkConnectivity
@@ -176,52 +176,52 @@ class TestPerformGNSSAction(
     # Test fail on invalid param
 
     async def test_fails_on_invalid_param(self):
-        self.assert_false(await modem.perform_gnss_action(action=-10))
+        self.assert_false(await modem.gnss_perform_action(action=-10))
     
     async def test_cme_4_set_in_modem_rsp_on_invalid_param(self):
         modem_rsp = ModemRsp()
-        await modem.perform_gnss_action(action=-10, rsp=modem_rsp)
+        await modem.gnss_perform_action(action=-10, rsp=modem_rsp)
 
         self.assert_equal(WalterModemCMEError.OPERATION_NOT_SUPPORTED, modem_rsp.cme_error)
     
     # Test normal run
 
     async def test_returns_true_on_no_param(self):
-        self.assert_true(await modem.perform_gnss_action())
+        self.assert_true(await modem.gnss_perform_action())
         await asyncio.sleep(1)
         await modem._run_cmd('AT+LPGNSSFIXPROG="stop"', b'OK')
 
-    async def test_perform_gnss_action_single_fix_runs(self):
-        self.assert_true(await modem.perform_gnss_action(action=WalterModemGNSSAction.GET_SINGLE_FIX))
+    async def test_gnss_perform_action_single_fix_runs(self):
+        self.assert_true(await modem.gnss_perform_action(action=WalterModemGNSSAction.GET_SINGLE_FIX))
         await asyncio.sleep(1)
         await modem._run_cmd('AT+LPGNSSFIXPROG="stop"', b'OK')
     
-    async def test_perform_gnss_action_cancel_runs(self):
+    async def test_gnss_perform_action_cancel_runs(self):
         await modem._run_cmd('AT+LPGNSSFIXPROG="single"', b'OK')
         await asyncio.sleep(1)
-        self.assert_true(await modem.perform_gnss_action(action=WalterModemGNSSAction.CANCEL))
+        self.assert_true(await modem.gnss_perform_action(action=WalterModemGNSSAction.CANCEL))
 
-class TestWaitForGNSSFix(
+class TestGNSSWaitForFix(
     AsyncTestCase,
     WalterModemAsserts
 ):
     async def async_setup(self):
         await modem.begin() # Modem begin is idempotent
 
-    async def test_wait_for_gnss_fix_returns_gnss_fix(self):
+    async def test_returns_gnss_fix(self):
         await modem._run_cmd('AT+LPGNSSFIXPROG="single"', b'OK')
         try:
-            result = await asyncio.wait_for(modem.wait_for_gnss_fix(), timeout=180)
+            result = await asyncio.wait_for(modem.gnss_wait_for_fix(), timeout=180)
             self.assert_is_instance(result, ModemGNSSFix)
         except asyncio.TimeoutError:
-            raise OSError('Runtime Error, timeout whilst waiting for "wait_for_gnss_fix"')
+            raise OSError('Runtime Error, timeout whilst waiting for "gnss_wait_for_fix"')
 
 testcases = [testcase() for testcase in (
-    TestConfigGNNS,
-    TestGetGNNSAssistanceStatus,
-    TestUpdateGNNSAssistance,
-    TestPerformGNSSAction,
-    TestWaitForGNSSFix,
+    TestGNSSConfig,
+    TestGNNSAssistanceGetStatus,
+    TestGNNSAssistanceUpdate,
+    TestGNSSPerformAction,
+    TestGNSSWaitForFix,
 )]
 
 for testcase in testcases:

--- a/tests/modem_library/test_http.py
+++ b/tests/modem_library/test_http.py
@@ -36,7 +36,7 @@ class TestHTTP(unittest.AsyncTestCase, unittest.WalterModemAsserts):
         modem_rsp = ModemRsp()
         await modem.begin()
 
-        await modem.create_PDP_context(context_id=1)
+        await modem.pdp_context_create(context_id=1)
 
         await modem.get_op_state(rsp=modem_rsp)
         if modem_rsp.op_state is not WalterModemOpState.FULL:

--- a/tests/modem_library/test_mqtt.py
+++ b/tests/modem_library/test_mqtt.py
@@ -36,7 +36,7 @@ class TestMQTT(unittest.AsyncTestCase, unittest.WalterModemAsserts):
         modem_rsp = ModemRsp()
         await modem.begin()
 
-        await modem.create_PDP_context()
+        await modem.pdp_context_create()
 
         await modem.get_op_state(rsp=modem_rsp)
         if modem_rsp.op_state is not WalterModemOpState.FULL:

--- a/tests/modem_library/test_pdp_ctx_mgnt.py
+++ b/tests/modem_library/test_pdp_ctx_mgnt.py
@@ -51,14 +51,14 @@ class TestPDPContextManagementPreConnection(unittest.AsyncTestCase, unittest.Wal
         )
     
     # ---
-    # create_pdp_context()
+    # pdp_context_create()
 
-    async def test_create_pdp_context_runs(self):
-        self.assert_true(await modem.create_PDP_context())
+    async def test_pdp_context_create_runs(self):
+        self.assert_true(await modem.pdp_context_create())
 
-    async def test_create_pdp_context_correctly_creates_context_in_modem(self):
+    async def test_pdp_context_create_correctly_creates_context_in_modem(self):
         modem_rsp = ModemRsp()
-        if not await modem.create_PDP_context(
+        if not await modem.pdp_context_create(
             context_id=PDP_CTX_ID,
             apn=APN,
             pdp_type=WalterModemPDPType.IP,
@@ -95,11 +95,11 @@ class TestPDPContextManagementPreConnection(unittest.AsyncTestCase, unittest.Wal
         self.assert_equal(b'"IP","",,,,1,0,1,1,0,0,1,,0', pdp_ctx_str_from_modem)
     
     # ---
-    # set_pdp_auth_params()
+    # pdp_set_auth_params()
 
-    async def test_set_pdp_auth_params_runs(self):
+    async def test_pdp_set_auth_params_runs(self):
         self.assert_true(
-            await modem.set_PDP_auth_params(
+            await modem.pdp_set_auth_params(
                 context_id=PDP_CTX_ID,
                 protocol=AUTH_PROTO,
                 user_id=AUTH_USER,
@@ -107,12 +107,12 @@ class TestPDPContextManagementPreConnection(unittest.AsyncTestCase, unittest.Wal
             )
         )
     
-    async def test_set_pdp_auth_params_sends_correct_at_cmd(self):
+    async def test_pdp_set_auth_params_sends_correct_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CGAUTH={PDP_CTX_ID},{AUTH_PROTO},'
             f'"{AUTH_USER if AUTH_USER else ''}","{AUTH_PASS if AUTH_PASS else ''}"',
-            lambda: modem.set_PDP_auth_params(PDP_CTX_ID, AUTH_PROTO, AUTH_USER, AUTH_PASS)
+            lambda: modem.pdp_set_auth_params(PDP_CTX_ID, AUTH_PROTO, AUTH_USER, AUTH_PASS)
         )
 
 class TestPDPContextManagementPostConnection(unittest.AsyncTestCase, unittest.WalterModemAsserts):
@@ -120,7 +120,7 @@ class TestPDPContextManagementPostConnection(unittest.AsyncTestCase, unittest.Wa
         modem_rsp = ModemRsp()
         await modem.begin()
 
-        await modem.create_PDP_context(context_id=PDP_CTX_ID)
+        await modem.pdp_context_create(context_id=PDP_CTX_ID)
 
         await modem.get_op_state(rsp=modem_rsp)
         if modem_rsp.op_state is not WalterModemOpState.FULL:
@@ -135,51 +135,51 @@ class TestPDPContextManagementPostConnection(unittest.AsyncTestCase, unittest.Wa
         )
     
     # ---
-    # set_pdp_context_active()
+    # pdp_context_set_active()
     
-    async def test_set_pdp_context_active_runs(self):
+    async def test_pdp_context_set_active_runs(self):
         self.assert_true(
-            await modem.set_PDP_context_active(
+            await modem.pdp_context_set_active(
                 active=True,
                 context_id=PDP_CTX_ID,
             )
         )
     
-    async def test_set_pdp_context_active_sends_correct_at_cmd(self):
+    async def test_pdp_context_set_active_sends_correct_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CGACT=1,{PDP_CTX_ID}',
-            lambda: modem.set_PDP_context_active(True, PDP_CTX_ID)
+            lambda: modem.pdp_context_set_active(True, PDP_CTX_ID)
         )
     
     # ---
-    # get_pdp_address()
+    # pdp_get_addressess()
     
-    async def test_get_pdp_address_runs(self):
+    async def test_pdp_get_addressess_runs(self):
         modem_rsp = ModemRsp()
-        self.assert_true(await modem.get_PDP_address(context_id=PDP_CTX_ID, rsp=modem_rsp))
+        self.assert_true(await modem.pdp_get_addressess(context_id=PDP_CTX_ID, rsp=modem_rsp))
     
-    async def test_get_pdp_address_sets_correct_response_type(self):
+    async def test_pdp_get_addressess_sets_correct_response_type(self):
         modem_rsp = ModemRsp()
-        await modem.get_PDP_address(context_id=PDP_CTX_ID, rsp=modem_rsp)
+        await modem.pdp_get_addressess(context_id=PDP_CTX_ID, rsp=modem_rsp)
         self.assert_equal(WalterModemRspType.PDP_ADDR, modem_rsp.type)
     
-    async def test_get_pdp_address_sets_pdp_address_list_in_response(self):
+    async def test_pdp_get_addressess_sets_pdp_address_list_in_response(self):
         modem_rsp = ModemRsp()
-        await modem.get_PDP_address(context_id=PDP_CTX_ID, rsp=modem_rsp)
+        await modem.pdp_get_addressess(context_id=PDP_CTX_ID, rsp=modem_rsp)
         self.assert_is_instance(modem_rsp.pdp_address_list, list)
     
     # ---
     # attach_pdp_context()
     
-    async def test_set_network_attachment_state_runs(self):
-        self.assert_true(await modem.set_network_attachment_state(attach=True))
+    async def test_pdp_set_attach_state_runs(self):
+        self.assert_true(await modem.pdp_set_attach_state(attach=True))
     
-    async def test_set_network_attachment_state_sends_correct_at_cmd(self):
+    async def test_pdp_set_attach_state_sends_correct_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             'AT+CGATT=1',
-            lambda: modem.set_network_attachment_state(True)
+            lambda: modem.pdp_set_attach_state(True)
         )
 
 

--- a/tests/modem_library/test_sleep_methods.py
+++ b/tests/modem_library/test_sleep_methods.py
@@ -16,55 +16,55 @@ class TestSleepMethods(unittest.AsyncTestCase, unittest.WalterModemAsserts):
         await modem.begin()
 
     async def async_teardown(self):
-        await modem.config_PSM(WalterModemPSMMode.DISABLE_AND_DISCARD_ALL_PARAMS)
-        await modem.config_EDRX(WalterModemEDRXMODE.DISABLE_AND_DISCARD_ALL_PARAMS)
+        await modem.config_psm(WalterModemPSMMode.DISABLE_AND_DISCARD_ALL_PARAMS)
+        await modem.config_edrx(WalterModemEDRXMODE.DISABLE_AND_DISCARD_ALL_PARAMS)
 
-    async def test_config_PSM_sends_correct_at_cmd(self):
+    async def test_config_psm_sends_correct_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CPSMS=0',
-            lambda: modem.config_PSM(WalterModemPSMMode.DISABLE_PSM)
+            lambda: modem.config_psm(WalterModemPSMMode.DISABLE_PSM)
         )
     
-    async def test_config_PSM_sends_correct_at_cmd_with_tau(self):
+    async def test_config_psm_sends_correct_at_cmd_with_tau(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CPSMS=1,,,"10010111"',
-            lambda: modem.config_PSM(
+            lambda: modem.config_psm(
                 mode=WalterModemPSMMode.ENABLE_PSM,
                 periodic_TAU_s=678
             )
         )
     
-    async def test_config_PSM_sends_correct_at_cmd_with_active_time(self):
+    async def test_config_psm_sends_correct_at_cmd_with_active_time(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CPSMS=1,,,,"00000010"',
-            lambda: modem.config_PSM(
+            lambda: modem.config_psm(
                 mode=WalterModemPSMMode.ENABLE_PSM,
                 active_time_s=5
             )
         )
 
-    async def test_config_PSM_sends_correct_at_cmd_with_tau_and_active_time(self):
+    async def test_config_psm_sends_correct_at_cmd_with_tau_and_active_time(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+CPSMS=1,,,"10010111","00000010"',
-            lambda: modem.config_PSM(
+            lambda: modem.config_psm(
                 mode=WalterModemPSMMode.ENABLE_PSM,
                 periodic_TAU_s=678,
                 active_time_s=5
             )
         )
     
-    async def test_config_EDRX_sends_correct_at_cmd(self):
+    async def test_config_edrx_sends_correct_at_cmd(self):
         await self.assert_sends_at_command(
             modem,
             f'AT+SQNEDRX=0',
-            lambda: modem.config_EDRX(WalterModemEDRXMODE.DISABLE_EDRX)
+            lambda: modem.config_edrx(WalterModemEDRXMODE.DISABLE_EDRX)
         )
 
-    async def test_config_EDRX_sends_correct_at_cmd_with_req_edrx_val_and_req_ptw(self):
+    async def test_config_edrx_sends_correct_at_cmd_with_req_edrx_val_and_req_ptw(self):
         modem_rsp = ModemRsp()
         await modem.get_rat(modem_rsp)
         rat = modem_rsp.rat
@@ -72,7 +72,7 @@ class TestSleepMethods(unittest.AsyncTestCase, unittest.WalterModemAsserts):
         await self.assert_sends_at_command(
             modem,
             f'AT+SQNEDRX=1,{rat + 3},"0101","0001"',
-            lambda: modem.config_EDRX(
+            lambda: modem.config_edrx(
                 mode=WalterModemEDRXMODE.ENABLE_EDRX,
                 req_edrx_val='0101',
                 req_ptw='0001'

--- a/tests/modem_library/test_sockets.py
+++ b/tests/modem_library/test_sockets.py
@@ -34,7 +34,7 @@ class TestSockets(unittest.AsyncTestCase, unittest.WalterModemAsserts):
         modem_rsp = ModemRsp()
         await modem.begin()
 
-        await modem.create_PDP_context(context_id=1)
+        await modem.pdp_context_create(context_id=1)
 
         await modem.get_op_state(rsp=modem_rsp)
         if modem_rsp.op_state is not WalterModemOpState.FULL:

--- a/tests/modem_library/test_sockets.py
+++ b/tests/modem_library/test_sockets.py
@@ -42,19 +42,19 @@ class TestSockets(unittest.AsyncTestCase, unittest.WalterModemAsserts):
 
         await await_connection()
 
-        self.create_socket_modem_rsp = ModemRsp()
+        self.socket_create_modem_rsp = ModemRsp()
 
     # ---
-    # create_socket()
+    # socket_create()
 
-    async def test_create_socket_runs(self):
-        self.assert_true(await modem.create_socket(rsp=self.create_socket_modem_rsp))
+    async def test_socket_create_runs(self):
+        self.assert_true(await modem.socket_create(rsp=self.socket_create_modem_rsp))
     
-    async def test_create_socket_sends_correct_at_command(self):
+    async def test_socket_create_sends_correct_at_command(self):
         await self.assert_sends_at_command(
             modem,
             'AT+SQNSCFG=2,1,500,120,900,30',
-            lambda: modem.create_socket(
+            lambda: modem.socket_create(
                 pdp_context_id=1,
                 mtu=500,
                 exchange_timeout=120,
@@ -63,17 +63,17 @@ class TestSockets(unittest.AsyncTestCase, unittest.WalterModemAsserts):
             )
         )
     
-    async def test_create_socket_sets_correct_response_type(self):
-        self.assert_equal(WalterModemRspType.SOCKET_ID, self.create_socket_modem_rsp.type)
+    async def test_socket_create_sets_correct_response_type(self):
+        self.assert_equal(WalterModemRspType.SOCKET_ID, self.socket_create_modem_rsp.type)
     
-    async def test_create_socket_sets_socket_id_in_response(self):
-        self.assert_is_instance(self.create_socket_modem_rsp.socket_id, int)
+    async def test_socket_create_sets_socket_id_in_response(self):
+        self.assert_is_instance(self.socket_create_modem_rsp.socket_id, int)
     
     # ---
-    # connect_socket()
+    # socket_connect()
 
-    async def test_connect_socket_runs(self):
-        self.assert_true(await modem.connect_socket(
+    async def test_socket_connect_runs(self):
+        self.assert_true(await modem.socket_connect(
             remote_host='walterdemo.quickspot.io',
             remote_port=1999,
             local_port=1999
@@ -92,8 +92,8 @@ class TestSockets(unittest.AsyncTestCase, unittest.WalterModemAsserts):
     # ---
     # socket_close()
 
-    async def test_close_socket(self):
-        self.assert_true(await modem.close_socket())
+    async def test_socket_close(self):
+        self.assert_true(await modem.socket_close())
 
 test_sockets = TestSockets()
 test_sockets.run()

--- a/walter_modem/mixins/gnss.py
+++ b/walter_modem/mixins/gnss.py
@@ -13,8 +13,32 @@ from ..structs import (
 )
 
 class ModemGNSS(ModemCore):
-    async def config_gnss(
-        self,
+
+    # Deprecated aliases, to bre removed in a later release
+
+    async def config_gnss(self, *args, **kwargs):
+        """DEPRECATED; use `gnss_config()` instead."""
+        return await self.gnss_config(*args, **kwargs)
+    
+    async def get_gnss_assistance_status(self, *args, **kwargs):
+        """DEPRECATED; use `gnss_assistance_get_status()` instead"""
+        return await self.gnss_assistance_get_status(*args, **kwargs)
+    
+    async def update_gnss_assistance(self, *args, **kwargs):
+        """DEPRECATED; use `gnss_assistance_update()` instead"""
+        return await self.gnss_assistance_update(*args, **kwargs)
+    
+    async def perform_gnss_action(self, *args, **kwargs):
+        """DEPRECATED; use `gnss_perform_action()` instead"""
+        return await self.gnss_perform_action(*args, **kwargs)
+    
+    async def wait_for_gnss_fix(self):
+        """DEPRECATED; use `gnss_wait_for_fix()` instead"""
+        return await self.gnss_wait_for_fix()
+
+    # ---
+
+    async def gnss_config(self,
         sens_mode: int = WalterModemGNSSSensMode.HIGH,
         acq_mode: int = WalterModemGNSSAcqMode.COLD_WARM_START,
         loc_mode: int = WalterModemGNSSLocMode.ON_DEVICE_LOCATION,
@@ -42,7 +66,9 @@ class ModemGNSS(ModemCore):
             at_rsp=b'OK'
         )
 
-    async def get_gnss_assistance_status(self, rsp: ModemRsp = None) -> bool:
+    async def gnss_assistance_get_status(self,
+        rsp: ModemRsp = None
+    ) -> bool:
         """
         Retrieves the status of the assistance data currently loaded in the GNSS subsystem.
 
@@ -56,7 +82,7 @@ class ModemGNSS(ModemCore):
             at_rsp=b'OK'
         )
     
-    async def update_gnss_assistance(self,
+    async def gnss_assistance_update(self,
         type: int = WalterModemGNSSAssistanceType.REALTIME_EPHEMERIS, 
         rsp: ModemRsp = None
     ) -> bool:
@@ -77,7 +103,7 @@ class ModemGNSS(ModemCore):
             at_rsp=b'+LPGNSSASSISTANCE:'
         )
     
-    async def perform_gnss_action(self,
+    async def gnss_perform_action(self,
         action: int = WalterModemGNSSAction.GET_SINGLE_FIX,
         rsp: ModemRsp = None
     ) -> bool:
@@ -103,7 +129,7 @@ class ModemGNSS(ModemCore):
             at_rsp=b'OK'
         )
 
-    async def wait_for_gnss_fix(self) -> ModemGNSSFix:
+    async def gnss_wait_for_fix(self) -> ModemGNSSFix:
         """
         Waits for a gnss fix before then returning it.
 

--- a/walter_modem/mixins/pdp.py
+++ b/walter_modem/mixins/pdp.py
@@ -18,7 +18,32 @@ from ..utils import (
 )
 
 class ModemPDP(ModemCore):
-    async def create_PDP_context(self,
+
+    # Deprecated aliases, to be removed in a later release
+
+    async def create_PDP_context(self, *args, **kwargs):
+        """DEPRECATED; use `pdp_context_create()` instead"""
+        return await self.pdp_context_create(*args, **kwargs)
+    
+    async def set_PDP_auth_params(self, *args, **kwargs):
+        """DEPRECATED; use `pdp_set_auth_params()` instead"""
+        return await self.pdp_set_auth_params(*args, **kwargs)
+    
+    async def set_PDP_context_active(self, *args, **kwargs):
+        """DEPRECATED; use `pdp_context_set_active()` instead"""
+        return await self.pdp_context_set_active(*args, **kwargs)
+    
+    async def set_network_attachment_state(self, *args, **kwargs):
+        """DEPRECATED; use `pdp_set_attach_state()` instead"""
+        return await self.pdp_set_attach_state(*args, **kwargs)
+    
+    async def get_PDP_address(self, *args, **kwargs):
+        """DEPRECATED; use `pdp_get_addressess()` instead"""
+        return await self.pdp_get_addressess(*args, **kwargs)
+
+    # ---
+
+    async def pdp_context_create(self,
         context_id: int = ModemCore.DEFAULT_PDP_CTX_ID,
         apn: str = '',
         pdp_type: str = WalterModemPDPType.IP,
@@ -84,7 +109,7 @@ class ModemPDP(ModemCore):
             at_rsp=b'OK'
         )
     
-    async def set_PDP_auth_params(self,
+    async def pdp_set_auth_params(self,
         context_id: int = ModemCore.DEFAULT_PDP_CTX_ID,
         protocol: int = WalterModemPDPAuthProtocol.NONE,
         user_id: str = None,
@@ -117,7 +142,7 @@ class ModemPDP(ModemCore):
             at_rsp=b'OK'
         )
     
-    async def set_PDP_context_active(self,
+    async def pdp_context_set_active(self,
         active: bool = True,
         context_id: int = ModemCore.DEFAULT_PDP_CTX_ID,
         rsp: ModemRsp = None
@@ -141,7 +166,7 @@ class ModemPDP(ModemCore):
             at_rsp=b'OK'
         )
         
-    async def set_network_attachment_state(self,
+    async def pdp_set_attach_state(self,
         attach: bool = True,
         rsp: ModemRsp = None
     ) -> bool:
@@ -159,7 +184,7 @@ class ModemPDP(ModemCore):
             at_rsp=b'OK'
         )
     
-    async def get_PDP_address(self,
+    async def pdp_get_addressess(self,
         context_id: int = ModemCore.DEFAULT_PDP_CTX_ID,
         rsp: ModemRsp = None
     ) -> bool:

--- a/walter_modem/mixins/sleep.py
+++ b/walter_modem/mixins/sleep.py
@@ -33,6 +33,19 @@ _PSM_ACTIVE_UNIT_OPTIONS = (
 )
 
 class ModemSleep(ModemCore):
+
+    # Deprecated aliases, to be removed in a later release
+
+    async def config_PSM(self, *args, **kwargs):
+        """DEPRECATED; use `config_psm()` instead"""
+        return await self.config_psm(*args, **kwargs)
+    
+    async def config_EDRX(self, *args, **kwargs):
+        """DEPRECATED; use `config_edrx()` instead"""
+        return await self.config_edrx(*args, **kwargs)
+
+    # ---
+
     def sleep(self,
         sleep_time_ms: int,
         light_sleep: bool = False,
@@ -119,9 +132,9 @@ class ModemSleep(ModemCore):
                 f'No valid encoding for Active Time={active_time_s}s found, skipping property')
             return None
         
-        return f'{code:08b}'
+        return f'{code:08b}'    
     
-    async def config_PSM(self,
+    async def config_psm(self,
         mode: int,
         periodic_TAU_s: int = None,
         active_time_s: int = None,
@@ -168,7 +181,7 @@ class ModemSleep(ModemCore):
             at_rsp=b'OK'
         )
 
-    async def config_EDRX(self,
+    async def config_edrx(self,
         mode: int,
         req_edrx_val: str = None,
         req_ptw: str = None,

--- a/walter_modem/mixins/socket.py
+++ b/walter_modem/mixins/socket.py
@@ -16,7 +16,24 @@ from ..utils import (
 )
 
 class ModemSocket(ModemCore):
-    async def create_socket(self,
+
+    # Deprecated aliases, to be removed in a later release
+
+    async def create_socket(self, *args, **kwargs):
+        """DEPRECATED; use `socket_create()` instead"""
+        return await self.socket_create(*args, **kwargs)
+    
+    async def connect_socket(self, *args, **kwargs):
+        """DEPRECATED; use `socket_connect()` instead"""
+        return await self.socket_connect(*args, **kwargs)
+    
+    async def close_socket(self, *args, **kwargs):
+        """DEPRECATED; use `socket_close()` instead"""
+        return await self.socket_close(*args, **kwargs)
+
+    # ---
+
+    async def socket_create(self,
         pdp_context_id: int = ModemCore.DEFAULT_PDP_CTX_ID,
         mtu: int = 300,
         exchange_timeout: int = 90,
@@ -80,7 +97,7 @@ class ModemSocket(ModemCore):
             complete_handler_arg=socket
         )
     
-    async def connect_socket(self,
+    async def socket_connect(self,
         remote_host: str,
         remote_port: int,
         local_port: int = 0,
@@ -135,9 +152,11 @@ class ModemSocket(ModemCore):
             complete_handler=complete_handler,
             complete_handler_arg=socket
         )
-
     
-    async def close_socket(self, socket_id: int = -1, rsp: ModemRsp = None) -> bool:
+    async def socket_close(self,
+        socket_id: int = -1,
+        rsp: ModemRsp = None
+    ) -> bool:
         """
         Closes a socket. Sockets can only be closed when suspended; 
         active connections cannot be closed.        

--- a/walter_modem/structs.py
+++ b/walter_modem/structs.py
@@ -359,7 +359,7 @@ class ModemSocket:
 
 
 class ModemGnssFixWaiter:
-    """Represents a wait_for_gnss_fix call that is waiting for data"""
+    """Represents a gnss_wait_for_fix call that is waiting for data"""
     def __init__(self):
         self.event = Event()
         self.gnss_fix = None


### PR DESCRIPTION
Corrected method naming whilst provided aliases with deprecation warninings for the old names.

| Before | After _(reworded)_ |
| --- | --- |
| **GNSS** | |
| config_gnss | gnss_config |
| get_gnss_assistance_status | gnss_assistance_get_status |
| update_gnss_assistance | gnss_assistance_update |
| perform_gnss_action | gnss_perform_action |
| wait_for_gnss_fix | gnss_wait_for_fix |
| **PDP** | |
| create_PDP_context | pdp_context_create |
| set_PDP_auth_params | pdp_set_auth_params |
| set_PDP_context_active | pdp_context_set_active |
| set_network_attachment_state | pdp_set_attach_state |
| get_PDP_address | pdp_get_addressess |
| **Sleep** | |
| config_PSM | config_psm |
| config_EDRX | config_edrx |
| **Sockets** | |
| create_socket | socket_create |
| connect_socket | socket_connect |
| close_socket | socket_close |

Closes #50 
